### PR TITLE
Fix WeaverComponents not being enabled/disabled from the component list inspector

### DIFF
--- a/Assets/Weaver/Editor/Inspectors/ComponentControllerDrawer.cs
+++ b/Assets/Weaver/Editor/Inspectors/ComponentControllerDrawer.cs
@@ -50,14 +50,20 @@ namespace Weaver.Editors
             rect.height = EditorGUIUtility.singleLineHeight;
             rect.y += 2.0f;
             SerializedProperty element = m_SubObjects.GetArrayElementAtIndex(index);
-            SerializedObject serializedObject = new SerializedObject(element.objectReferenceValue);
             rect.width -= 20f;
             GUI.Label(rect, element.objectReferenceValue.name, EditorStyles.textArea);
             rect.x += rect.width;
             rect.width = 20f;
-            SerializedProperty isEnabled = serializedObject.FindProperty("m_Enabled");
-            isEnabled.boolValue = EditorGUI.Toggle(rect, isEnabled.boolValue);
-            serializedObject.ApplyModifiedProperties();
+            var weaverComponent = element.objectReferenceValue as WeaverComponent;
+            if (weaverComponent != null)
+            {
+                EditorGUI.BeginChangeCheck();
+                weaverComponent.IsEnabled =  EditorGUI.Toggle(rect, weaverComponent.IsEnabled);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    EditorUtility.SetDirty(weaverComponent);
+                }
+            }
         }
 
         private void OnDrawHeader(Rect rect)

--- a/Assets/Weaver/Editor/WeaverExtension.cs
+++ b/Assets/Weaver/Editor/WeaverExtension.cs
@@ -34,6 +34,14 @@ namespace Weaver
             get { return m_IsEnabled && m_RequiredScriptingSymbols.isActive; }
         }
 
+        public bool IsEnabled
+        {
+            get { return m_IsEnabled; }
+#if UNITY_EDITOR
+            set { m_IsEnabled = value; }
+#endif
+        }
+
         /// <summary>
         /// Returns back the type system for the module
         /// currently being edited. If we are not editing a module this


### PR DESCRIPTION
Prior to making this fix, I thought Weaver simply didn't work. I debugged for a while and finally found this surprise:

![woops](https://user-images.githubusercontent.com/601503/35291575-94e78fb0-0022-11e8-84e2-114a227debd7.jpg)

As you can see, I had an ENABLED component in the "Weaver Settings" inspector, but when I expanded the Weaver Settings object in the project and looked at that WeaverComponent child, it was DISABLED. So no weaving was happening.

It took me quite a while to realize this, so if you don't like *this* fix, you should at least consider something like this, because new users will definitely think that Weaver doesn't work "out of the box" otherwise.