### PR TITLE
WeaverAssemblyResolver, WeavedAssembly bugfixes

### DIFF
--- a/Assets/Weaver/Editor/Resolver/WeaverAssemblyResolver.cs
+++ b/Assets/Weaver/Editor/Resolver/WeaverAssemblyResolver.cs
@@ -9,33 +9,40 @@ namespace Weaver
     /// Used to resolve any references to assemblies that are current in the unity 
     /// project.
     /// </summary>
-    public class WeaverAssemblyResolver : DefaultAssemblyResolver
+    public class WeaverAssemblyResolver : BaseAssemblyResolver
     {
+        // map of assembly locations
         private readonly IDictionary<string, string> _appDomainAssemblyLocations;
+        // cache of loaded AssemblyDefinitions
+        private readonly IDictionary<string, AssemblyDefinition> _cache;
 
         public WeaverAssemblyResolver()
         {
-            // Create a map
+            // Caches
             _appDomainAssemblyLocations = new Dictionary<string, string>();
+            _cache = new Dictionary<string, AssemblyDefinition>();
             // Get the current app domain
             AppDomain domain = AppDomain.CurrentDomain;
             // Find all assemblies
             Assembly[] assemblies = domain.GetAssemblies();
-            // Loop over all assemblies and populate the map
-            for(int i = 0; i < assemblies.Length; i++)
+            // for each currently loaded assembly,
+            for (int i = 0; i < assemblies.Length; i++)
             {
+                // store locations
                 _appDomainAssemblyLocations[assemblies[i].FullName] = assemblies[i].Location;
+                // add all directories as search paths
+                AddSearchDirectory(System.IO.Path.GetDirectoryName(assemblies[i].Location));
             }
         }
 
         public override AssemblyDefinition Resolve(string fullName)
         {
-            AssemblyDefinition assemblyDef = FindAssemblyDefinition(fullName);
+            AssemblyDefinition assemblyDef = FindAssemblyDefinition(fullName, null);
 
             if (assemblyDef == null)
             {
-             
                 assemblyDef = base.Resolve(fullName);
+                _cache[fullName] = assemblyDef;
             }
 
             return assemblyDef;
@@ -43,23 +50,12 @@ namespace Weaver
 
         public override AssemblyDefinition Resolve(AssemblyNameReference name)
         {
-            AssemblyDefinition assemblyDef = FindAssemblyDefinition(name.FullName); 
+            AssemblyDefinition assemblyDef = FindAssemblyDefinition(name.FullName, null);
 
             if (assemblyDef == null)
             {
                 assemblyDef = base.Resolve(name);
-            }
-
-            return assemblyDef;
-        }
-
-        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
-        {
-            AssemblyDefinition assemblyDef = FindAssemblyDefinition(name.FullName); 
-
-            if (assemblyDef == null)
-            {
-                assemblyDef = base.Resolve(name, parameters);
+                _cache[name.FullName] = assemblyDef;
             }
 
             return assemblyDef;
@@ -67,28 +63,64 @@ namespace Weaver
 
         public override AssemblyDefinition Resolve(string fullName, ReaderParameters parameters)
         {
-            AssemblyDefinition assemblyDef = FindAssemblyDefinition(fullName);
+            AssemblyDefinition assemblyDef = FindAssemblyDefinition(fullName, parameters);
 
             if (assemblyDef == null)
             {
                 assemblyDef = base.Resolve(fullName, parameters);
+                _cache[fullName] = assemblyDef;
+            }
+
+            return assemblyDef;
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            AssemblyDefinition assemblyDef = FindAssemblyDefinition(name.FullName, parameters);
+
+            if (assemblyDef == null)
+            {
+                assemblyDef = base.Resolve(name, parameters);
+                _cache[name.FullName] = assemblyDef;
             }
 
             return assemblyDef;
         }
 
         /// <summary>
-        /// Using the assembly map we try to find the assembly and create an Assembly Definition
+        /// Searches for AssemblyDefinition in our cache, and failing that,
+        /// looks for a known location.  Returns null if both attempts fail.
         /// </summary>
-        private AssemblyDefinition FindAssemblyDefinition(string strongName)
+        private AssemblyDefinition FindAssemblyDefinition(string fullName, ReaderParameters parameters)
         {
-            // Try to match their name
-            if(_appDomainAssemblyLocations.ContainsKey(strongName))
+            if (fullName == null)
             {
-                string location = _appDomainAssemblyLocations[strongName];
-                // Ready the assembly off disk.
-                return AssemblyDefinition.ReadAssembly(location);
+                throw new ArgumentNullException("fullName");
             }
+
+            // Look in cache first
+            AssemblyDefinition assemblyDefinition;
+            if (_cache.TryGetValue(fullName, out assemblyDefinition))
+            {
+                return assemblyDefinition;
+            }
+
+            // Try to use known location
+            if (_appDomainAssemblyLocations.ContainsKey(fullName))
+            {
+                string location = _appDomainAssemblyLocations[fullName];
+
+                // Ready the assembly off disk.
+                if (parameters != null)
+                    assemblyDefinition = AssemblyDefinition.ReadAssembly(location, parameters);
+                else
+                    assemblyDefinition = AssemblyDefinition.ReadAssembly(location);
+
+                _cache[fullName] = assemblyDefinition;
+
+                return assemblyDefinition;
+            }
+
             return null;
         }
     }

--- a/Assets/Weaver/Editor/Resolver/WeaverAssemblyResolver.cs
+++ b/Assets/Weaver/Editor/Resolver/WeaverAssemblyResolver.cs
@@ -98,18 +98,18 @@ namespace Weaver
                 throw new ArgumentNullException("fullName");
             }
 
-            // Look in cache first
             AssemblyDefinition assemblyDefinition;
+
+            // Look in cache first
             if (_cache.TryGetValue(fullName, out assemblyDefinition))
             {
                 return assemblyDefinition;
             }
 
             // Try to use known location
-            if (_appDomainAssemblyLocations.ContainsKey(fullName))
+            string location;
+            if (_appDomainAssemblyLocations.TryGetValue(fullName, out location))
             {
-                string location = _appDomainAssemblyLocations[fullName];
-
                 // Ready the assembly off disk.
                 if (parameters != null)
                     assemblyDefinition = AssemblyDefinition.ReadAssembly(location, parameters);

--- a/Assets/Weaver/Editor/Settings/WeaverSettings.cs
+++ b/Assets/Weaver/Editor/Settings/WeaverSettings.cs
@@ -249,6 +249,8 @@ namespace Weaver
                 {
                     m_Log.Info("Weaver Settings", "Writing Module <i>" + assemblies[i].relativePath + "</i> to disk.", false);
                     editingModules[i].Write(assemblies[i].GetSystemPath(), writerParameters);
+                    // remember write time of modified assembly
+                    assemblies[i].HasChanges();
                 }
                 assemblies.Clear();
                 m_Log.Info("Weaver Settings", "Weaving Successfully Completed", false);


### PR DESCRIPTION
Just a couple bugfixes!

- An improved WeaverAssemblyResolver, which caches the loaded AssemblyDefinition after the first resolve.  The old WeaverAssemblyResolver loaded a new AssemblyDefinition on each resolve (which actually happen quite often, especially during writes).  In weaving a project with ~300 types, this allocated over 1 GB of heap memory.

- WeaverSettings now remembers the write time of the weaved assembly, to prevent this version from being detected as having changes on a later reload.